### PR TITLE
add watcher when log delete, Automatically generate new log file

### DIFF
--- a/cmd/modis/main.go
+++ b/cmd/modis/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"github.com/fsnotify/fsnotify"
 
 	// "net/http"
 	// _ "net/http/pprof"
@@ -53,13 +54,21 @@ func main() {
 		fmt.Println("fail to load config", err)
 		os.Exit(1)
 	}
+
+	log_watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		fmt.Println("fail to init watcher, ", err)
+		os.Exit(1)
+	}
+	defer log_watcher.Close()
 	cfg := config.DefaultGlobalConfig
 
-	err = log.InitLoggerWithConfig(cfg.Log)
+	err = log.InitLoggerWithConfig(cfg.Log, log_watcher)
 	if err != nil {
 		fmt.Println("fail to init logger", err)
 		os.Exit(1)
 	}
+	defer log.Sync()
 
 	s, err := storage.Open(&cfg.Storage.ObkvConfig)
 	if err != nil {

--- a/test/util.go
+++ b/test/util.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/fsnotify/fsnotify"
+	"os"
 	"strconv"
 
 	"github.com/oceanbase/modis/config"
@@ -211,7 +213,14 @@ func InitLogger() {
 		Compress:          false,
 		Level:             "debug",
 	}
-	err := log.InitLoggerWithConfig(cfg)
+	log_watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		fmt.Println("fail to init watcher, ", err)
+		os.Exit(1)
+	}
+	defer log_watcher.Close()
+
+	err = log.InitLoggerWithConfig(cfg, log_watcher)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
add watcher when log delete, Automatically generate new log file
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
1. add watcher when log delete
2. lumberjack use local time
