### PR TITLE
Replace Hard-Coded Table with System Table Mapping for cmdName

### DIFF
--- a/cmd/modis/main.go
+++ b/cmd/modis/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+
 	"github.com/fsnotify/fsnotify"
 
 	// "net/http"
@@ -72,7 +73,7 @@ func main() {
 
 	s, err := storage.Open(&cfg.Storage.ObkvConfig)
 	if err != nil {
-		fmt.Println("open DB failed")
+		fmt.Println("open DB failed", err.Error())
 		log.Fatal("main", "", "open DB failed", log.Errors(err))
 		os.Exit(1)
 	}

--- a/command/hashes.go
+++ b/command/hashes.go
@@ -33,7 +33,7 @@ func HDel(ctx *CmdContext) error {
 	fields := make([][]byte, len(kvs))
 	copy(fields, kvs)
 
-	deleteNum, err := ctx.CodecCtx.DB.Storage.HDel(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, fields)
+	deleteNum, err := ctx.CodecCtx.DB.Storage.HDel(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, fields)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -50,7 +50,7 @@ func HSetNX(ctx *CmdContext) error {
 	} else {
 		field := ctx.Args[1]
 		value := ctx.Args[2]
-		insertCount, err := ctx.CodecCtx.DB.Storage.HSetNx(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, field, value)
+		insertCount, err := ctx.CodecCtx.DB.Storage.HSetNx(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, field, value)
 		if err != nil {
 			ctx.OutContent = resp.EncError("ERR " + err.Error())
 		} else {
@@ -64,7 +64,7 @@ func HSetNX(ctx *CmdContext) error {
 func HGet(ctx *CmdContext) error {
 	key := ctx.Args[0]
 	field := ctx.Args[1]
-	val, err := ctx.CodecCtx.DB.Storage.HGet(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, field)
+	val, err := ctx.CodecCtx.DB.Storage.HGet(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, field)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -80,7 +80,7 @@ func HGet(ctx *CmdContext) error {
 // HGetAll returns all fields and values of the hash stored at key
 func HGetAll(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	resValue, err := ctx.CodecCtx.DB.Storage.HGetAll(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	resValue, err := ctx.CodecCtx.DB.Storage.HGetAll(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -93,7 +93,7 @@ func HGetAll(ctx *CmdContext) error {
 func HExists(ctx *CmdContext) error {
 	key := ctx.Args[0]
 	field := ctx.Args[1]
-	val, err := ctx.CodecCtx.DB.Storage.HGet(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, field)
+	val, err := ctx.CodecCtx.DB.Storage.HGet(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, field)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -117,7 +117,7 @@ func HIncrBy(ctx *CmdContext) error {
 		return nil
 	}
 
-	res, err := ctx.CodecCtx.DB.Storage.HIncrBy(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, field, value)
+	res, err := ctx.CodecCtx.DB.Storage.HIncrBy(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, field, value)
 	if err != nil {
 		if strings.Contains(err.Error(), "-4262") {
 			ctx.OutContent = resp.EncError("ERR " + err.Error())
@@ -143,7 +143,7 @@ func HIncrByFloat(ctx *CmdContext) error {
 		return nil
 	}
 
-	f64, err := ctx.CodecCtx.DB.Storage.HIncrByFloat(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, field, value)
+	f64, err := ctx.CodecCtx.DB.Storage.HIncrByFloat(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, field, value)
 	if err != nil {
 		if strings.Contains(err.Error(), "-4262") {
 			ctx.OutContent = resp.EncError("ERR " + err.Error())
@@ -159,7 +159,7 @@ func HIncrByFloat(ctx *CmdContext) error {
 // HKeys returns all field names in the hash stored at key
 func HKeys(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	resValue, err := ctx.CodecCtx.DB.Storage.HKeys(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	resValue, err := ctx.CodecCtx.DB.Storage.HKeys(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -171,7 +171,7 @@ func HKeys(ctx *CmdContext) error {
 // HVals returns all values in the hash stored at key
 func HVals(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	resValue, err := ctx.CodecCtx.DB.Storage.HVals(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	resValue, err := ctx.CodecCtx.DB.Storage.HVals(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -183,7 +183,7 @@ func HVals(ctx *CmdContext) error {
 // HLen returns the number of fields contained in the hash stored at key
 func HLen(ctx *CmdContext) error {
 	key := []byte(ctx.Args[0])
-	size, err := ctx.CodecCtx.DB.Storage.HLen(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	size, err := ctx.CodecCtx.DB.Storage.HLen(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -199,7 +199,7 @@ func HMGet(ctx *CmdContext) error {
 	fields := make([][]byte, len(kvs))
 	copy(fields, kvs)
 
-	values, err := ctx.CodecCtx.DB.Storage.HMGet(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, fields)
+	values, err := ctx.CodecCtx.DB.Storage.HMGet(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, fields)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -216,7 +216,7 @@ func HashCmdWithKey(ctx *CmdContext) error {
 		table.NewColumn(dbColumnName, ctx.CodecCtx.DB.ID),
 		table.NewColumn(keyColumnName, key),
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, hashTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}

--- a/command/keys.go
+++ b/command/keys.go
@@ -65,7 +65,7 @@ func Exists(ctx *CmdContext) error {
 
 func ExpireCommon(ctx *CmdContext) error {
 	var err error
-	ctx.OutContent, err = GenericCmdWithKey(ctx, stringTableName)
+	ctx.OutContent, err = GenericCmdWithKey(ctx, "get")
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}

--- a/command/list.go
+++ b/command/list.go
@@ -17,9 +17,10 @@
 package command
 
 import (
+	"math"
+
 	"github.com/oceanbase/modis/protocol/resp"
 	"github.com/oceanbase/obkv-table-client-go/table"
-	"math"
 )
 
 func ListCmd(ctx *CmdContext) error {
@@ -30,7 +31,7 @@ func ListCmd(ctx *CmdContext) error {
 		table.NewColumn(keyColumnName, key),
 		table.NewColumn(indexColumnName, int64(math.MinInt64)),
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, listTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}

--- a/command/sets.go
+++ b/command/sets.go
@@ -29,7 +29,7 @@ import (
 func SMembers(ctx *CmdContext) error {
 	key := ctx.Args[0]
 
-	values, err := ctx.CodecCtx.DB.Storage.SMembers(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	values, err := ctx.CodecCtx.DB.Storage.SMembers(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -59,7 +59,7 @@ func SRandMember(ctx *CmdContext) error {
 		return nil
 	}
 
-	members, err := ctx.CodecCtx.DB.Storage.SRandMember(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, count)
+	members, err := ctx.CodecCtx.DB.Storage.SRandMember(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, count)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else if len(ctx.Args) == 1 {
@@ -79,7 +79,7 @@ func SRandMember(ctx *CmdContext) error {
 // SCard returns the set cardinality (number of elements) of the set stored at key
 func SCard(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	size, err := ctx.CodecCtx.DB.Storage.SCard(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	size, err := ctx.CodecCtx.DB.Storage.SCard(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -92,7 +92,7 @@ func SCard(ctx *CmdContext) error {
 func SIsmember(ctx *CmdContext) error {
 	key := ctx.Args[0]
 	member := ctx.Args[1]
-	returnValue, err := ctx.CodecCtx.DB.Storage.SIsmember(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, member)
+	returnValue, err := ctx.CodecCtx.DB.Storage.SIsmember(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, member)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -119,7 +119,7 @@ func SPop(ctx *CmdContext) error {
 		}
 	}
 
-	members, err := ctx.CodecCtx.DB.Storage.SPop(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, count)
+	members, err := ctx.CodecCtx.DB.Storage.SPop(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, count)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else if len(ctx.Args) == 1 {
@@ -143,7 +143,7 @@ func SRem(ctx *CmdContext) error {
 	for _, member := range ctx.Args[1:] {
 		members = append(members, []byte(member))
 	}
-	returnValue, err := ctx.CodecCtx.DB.Storage.SRem(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, members)
+	returnValue, err := ctx.CodecCtx.DB.Storage.SRem(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, members)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -158,7 +158,7 @@ func SMove(ctx *CmdContext) error {
 	dstKey := ctx.Args[1]
 	member := ctx.Args[2]
 
-	res, err := ctx.CodecCtx.DB.Storage.Smove(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, srcKey, dstKey, member)
+	res, err := ctx.CodecCtx.DB.Storage.Smove(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, srcKey, dstKey, member)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -174,7 +174,7 @@ func SetCmdWithKey(ctx *CmdContext) error {
 		table.NewColumn(dbColumnName, ctx.CodecCtx.DB.ID),
 		table.NewColumn(keyColumnName, key),
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, setTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}

--- a/command/strings.go
+++ b/command/strings.go
@@ -30,7 +30,7 @@ import (
 // Get the value of key
 func Get(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else if val == nil {
@@ -46,7 +46,7 @@ func Set(ctx *CmdContext) error {
 	key := ctx.Args[0]
 	value := ctx.Args[1]
 
-	err := ctx.CodecCtx.DB.Storage.Set(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, value)
+	err := ctx.CodecCtx.DB.Storage.Set(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, value)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -61,7 +61,7 @@ func MGet(ctx *CmdContext) error {
 	keys := make([][]byte, count)
 	copy(keys, ctx.Args)
 
-	resValues, err := ctx.CodecCtx.DB.Storage.MGet(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, keys)
+	resValues, err := ctx.CodecCtx.DB.Storage.MGet(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, keys)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -83,7 +83,7 @@ func MSet(ctx *CmdContext) error {
 			setValues[util.BytesToString(kv[0])] = kv[1]
 		}
 
-		_, err := ctx.CodecCtx.DB.Storage.MSet(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, setValues)
+		_, err := ctx.CodecCtx.DB.Storage.MSet(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, setValues)
 		if err != nil {
 			ctx.OutContent = resp.EncError("ERR " + err.Error())
 		} else {
@@ -96,7 +96,7 @@ func MSet(ctx *CmdContext) error {
 // Strlen returns the length of the string value stored at key
 func Strlen(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -109,7 +109,7 @@ func Strlen(ctx *CmdContext) error {
 func Append(ctx *CmdContext) error {
 	key := ctx.Args[0]
 	value := ctx.Args[1]
-	length, err := ctx.CodecCtx.DB.Storage.Append(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, value)
+	length, err := ctx.CodecCtx.DB.Storage.Append(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, value)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -122,7 +122,7 @@ func Append(ctx *CmdContext) error {
 func SetNx(ctx *CmdContext) error {
 	key := ctx.Args[0]
 	value := ctx.Args[1]
-	resValue, err := ctx.CodecCtx.DB.Storage.SetNx(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, value)
+	resValue, err := ctx.CodecCtx.DB.Storage.SetNx(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, value)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -147,7 +147,7 @@ func SetEx(ctx *CmdContext) error {
 	}
 	expireTimes := ui * uint64(time.Second)
 
-	err = ctx.CodecCtx.DB.Storage.SetEx(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, expireTimes, value)
+	err = ctx.CodecCtx.DB.Storage.SetEx(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, expireTimes, value)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -170,7 +170,7 @@ func PSetEx(ctx *CmdContext) error {
 	}
 	expireTimeMs := ui * uint64(time.Millisecond)
 
-	err = ctx.CodecCtx.DB.Storage.PSetEx(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, expireTimeMs, value)
+	err = ctx.CodecCtx.DB.Storage.PSetEx(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, expireTimeMs, value)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -182,7 +182,7 @@ func PSetEx(ctx *CmdContext) error {
 // Incr increments the integer value of a key  by one
 func Incr(ctx *CmdContext) error {
 	key := []byte(ctx.Args[0])
-	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, []byte("1"))
+	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, []byte("1"))
 	if err != nil {
 		ctx.OutContent = resp.ResponseIntegerErr
 	} else {
@@ -202,7 +202,7 @@ func IncrBy(ctx *CmdContext) error {
 		return nil
 	}
 
-	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, value)
+	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, value)
 	if err != nil {
 		ctx.OutContent = resp.ResponseIntegerErr
 	} else {
@@ -222,7 +222,7 @@ func IncrByFloat(ctx *CmdContext) error {
 		return nil
 	}
 
-	f64, err := ctx.CodecCtx.DB.Storage.IncrByFloat(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, value)
+	f64, err := ctx.CodecCtx.DB.Storage.IncrByFloat(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, value)
 	if err != nil {
 		if strings.Contains(err.Error(), "-5114") {
 			ctx.OutContent = resp.EncError("ERR value is not a valid float")
@@ -238,7 +238,7 @@ func IncrByFloat(ctx *CmdContext) error {
 // Decr decrements the integer value of a key by one
 func Decr(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, []byte("-1"))
+	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, []byte("-1"))
 	if err != nil {
 		ctx.OutContent = resp.ResponseIntegerErr
 	} else {
@@ -257,7 +257,7 @@ func DecrBy(ctx *CmdContext) error {
 		return nil
 	}
 
-	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, []byte(strconv.FormatInt(-delta, 10)))
+	res, err := ctx.CodecCtx.DB.Storage.IncrBy(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, []byte(strconv.FormatInt(-delta, 10)))
 	if err != nil {
 		ctx.OutContent = resp.ResponseIntegerErr
 	} else {
@@ -275,7 +275,7 @@ func GetBit(ctx *CmdContext) error {
 		return nil
 	}
 
-	res, err := ctx.CodecCtx.DB.Storage.GetBit(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, offset)
+	res, err := ctx.CodecCtx.DB.Storage.GetBit(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, offset)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -287,7 +287,7 @@ func GetBit(ctx *CmdContext) error {
 // BitCount counts the number of set bits (population counting) in a string.
 func BitCount(ctx *CmdContext) error {
 	key := ctx.Args[0]
-	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else if val == nil {
@@ -343,7 +343,7 @@ func SetRange(ctx *CmdContext) error {
 	}
 
 	// 1. get
-	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 		return nil
@@ -357,7 +357,7 @@ func SetRange(ctx *CmdContext) error {
 	}
 
 	// 3. insert
-	err = ctx.CodecCtx.DB.Storage.Set(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key, resBytes)
+	err = ctx.CodecCtx.DB.Storage.Set(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key, resBytes)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	} else {
@@ -370,7 +370,7 @@ func SetRange(ctx *CmdContext) error {
 func GetRange(ctx *CmdContext) error {
 	key := ctx.Args[0]
 
-	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.CodecCtx.DB.ID, key)
+	val, err := ctx.CodecCtx.DB.Storage.Get(ctx.CodecCtx.DB.Ctx, ctx.FullName, ctx.CodecCtx.DB.ID, key)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 		return nil
@@ -406,7 +406,7 @@ func StringCmdWithKey(ctx *CmdContext) error {
 		table.NewColumn(dbColumnName, ctx.CodecCtx.DB.ID),
 		table.NewColumn(keyColumnName, key),
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, stringTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}

--- a/command/zsets.go
+++ b/command/zsets.go
@@ -17,12 +17,13 @@
 package command
 
 import (
-	"github.com/oceanbase/modis/protocol/resp"
-	"github.com/oceanbase/obkv-table-client-go/table"
-	"github.com/oceanbase/obkv-table-client-go/util"
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/oceanbase/modis/protocol/resp"
+	"github.com/oceanbase/obkv-table-client-go/table"
+	"github.com/oceanbase/obkv-table-client-go/util"
 )
 
 func ZSetCmdWithKey(ctx *CmdContext) error {
@@ -32,7 +33,7 @@ func ZSetCmdWithKey(ctx *CmdContext) error {
 		table.NewColumn(dbColumnName, ctx.CodecCtx.DB.ID),
 		table.NewColumn(keyColumnName, key),
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, zsetTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}
@@ -46,7 +47,7 @@ func ZIncrBy(ctx *CmdContext) error {
 		table.NewColumn(keyColumnName, ctx.Args[0]),
 		table.NewColumn(memberColumnName, ctx.Args[2]),
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, zsetTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}
@@ -60,7 +61,7 @@ func ZSetCmdWithKeyMember(ctx *CmdContext) error {
 		table.NewColumn(keyColumnName, ctx.Args[0]),
 		table.NewColumn(memberColumnName, ctx.Args[1]),
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, zsetTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())
 	}
@@ -128,7 +129,7 @@ func ZRangeByScore(ctx *CmdContext) error {
 		new_args = append(new_args, ctx.Args...)
 		ctx.PlainReq = util.StringToBytes(resp.EncArray(new_args))
 	}
-	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, zsetTableName, rowKey, ctx.PlainReq)
+	ctx.OutContent, err = ctx.CodecCtx.DB.Storage.ObServerCmd(ctx.CodecCtx.DB.Ctx, ctx.FullName, rowKey, ctx.PlainReq)
 
 	if err != nil {
 		ctx.OutContent = resp.EncError("ERR " + err.Error())

--- a/storage/obkv/hash.go
+++ b/storage/obkv/hash.go
@@ -49,8 +49,11 @@ const (
 )
 
 // HGet hash get
-func (s *Storage) HGet(ctx context.Context, db int64, key []byte, field []byte) ([]byte, error) {
-	tableName := hashTableName
+func (s *Storage) HGet(ctx context.Context, cmdName string, db int64, key []byte, field []byte) ([]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -76,8 +79,11 @@ func (s *Storage) HGet(ctx context.Context, db int64, key []byte, field []byte) 
 }
 
 // HDel hash multi delete
-func (s *Storage) HDel(ctx context.Context, db int64, key []byte, fields [][]byte) (int64, error) {
-	tableName := hashTableName
+func (s *Storage) HDel(ctx context.Context, cmdName string, db int64, key []byte, fields [][]byte) (int64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	if len(fields) == 0 {
 		return 0, nil
@@ -119,8 +125,11 @@ func (s *Storage) HDel(ctx context.Context, db int64, key []byte, fields [][]byt
 }
 
 // HGetAll hash get all
-func (s *Storage) HGetAll(ctx context.Context, db int64, key []byte) ([][]byte, error) {
-	tableName := hashTableName
+func (s *Storage) HGetAll(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Prepare key range
 	startRowKey := []*table.Column{
@@ -166,8 +175,11 @@ func (s *Storage) HGetAll(ctx context.Context, db int64, key []byte) ([][]byte, 
 }
 
 // HKeys hash keys
-func (s *Storage) HKeys(ctx context.Context, db int64, key []byte) ([][]byte, error) {
-	tableName := hashTableName
+func (s *Storage) HKeys(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Prepare key range
 	startRowKey := []*table.Column{
@@ -212,8 +224,11 @@ func (s *Storage) HKeys(ctx context.Context, db int64, key []byte) ([][]byte, er
 }
 
 // HVals hash values
-func (s *Storage) HVals(ctx context.Context, db int64, key []byte) ([][]byte, error) {
-	tableName := hashTableName
+func (s *Storage) HVals(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Prepare key range
 	startRowKey := []*table.Column{
@@ -258,8 +273,11 @@ func (s *Storage) HVals(ctx context.Context, db int64, key []byte) ([][]byte, er
 }
 
 // HLen hash length
-func (s *Storage) HLen(ctx context.Context, db int64, key []byte) (int64, error) {
-	tableName := hashTableName
+func (s *Storage) HLen(ctx context.Context, cmdName string, db int64, key []byte) (int64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Prepare key range
 	startRowKey := []*table.Column{
@@ -289,8 +307,11 @@ func (s *Storage) HLen(ctx context.Context, db int64, key []byte) (int64, error)
 }
 
 // HSetNx hash set if not exist
-func (s *Storage) HSetNx(ctx context.Context, db int64, key []byte, field []byte, value []byte) (int, error) {
-	tableName := hashTableName
+func (s *Storage) HSetNx(ctx context.Context, cmdName string, db int64, key []byte, field []byte, value []byte) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -306,7 +327,7 @@ func (s *Storage) HSetNx(ctx context.Context, db int64, key []byte, field []byte
 	}
 
 	// Execute
-	_, err := s.cli.Insert(ctx, tableName, rowKey, mutates)
+	_, err = s.cli.Insert(ctx, tableName, rowKey, mutates)
 	if err != nil {
 		errString := err.Error()
 		errMsg := "errCode:-5024"
@@ -320,8 +341,11 @@ func (s *Storage) HSetNx(ctx context.Context, db int64, key []byte, field []byte
 }
 
 // HMGet hash multi get
-func (s *Storage) HMGet(ctx context.Context, db int64, key []byte, fields [][]byte) ([][]byte, error) {
-	tableName := hashTableName
+func (s *Storage) HMGet(ctx context.Context, cmdName string, db int64, key []byte, fields [][]byte) ([][]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create batch executor
 	batchExecutor := s.cli.NewBatchExecutor(tableName)
@@ -367,8 +391,11 @@ func (s *Storage) HMGet(ctx context.Context, db int64, key []byte, fields [][]by
 // HIncrBy Add value from the value of the key.
 // If the key does not exist, value is written and value is returned
 // Returns the value add value when key is present;
-func (s *Storage) HIncrBy(ctx context.Context, db int64, key []byte, field []byte, value []byte) (int64, error) {
-	tableName := hashTableName
+func (s *Storage) HIncrBy(ctx context.Context, cmdName string, db int64, key []byte, field []byte, value []byte) (int64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -401,8 +428,11 @@ func (s *Storage) HIncrBy(ctx context.Context, db int64, key []byte, field []byt
 // HIncrByFloat Add value from the value of the key.
 // If the key does not exist, value is written and value is returned
 // Returns the value add value when key is present;
-func (s *Storage) HIncrByFloat(ctx context.Context, db int64, key []byte, field []byte, value []byte) (float64, error) {
-	tableName := hashTableName
+func (s *Storage) HIncrByFloat(ctx context.Context, cmdName string, db int64, key []byte, field []byte, value []byte) (float64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -436,7 +466,7 @@ func (s *Storage) HIncrByFloat(ctx context.Context, db int64, key []byte, field 
 func (s *Storage) hashExists(ctx context.Context, db int64, keys [][]byte) (int64, error) {
 	var existNum int64
 	for _, key := range keys {
-		num, err := s.HLen(ctx, db, key)
+		num, err := s.HLen(ctx, "hlen", db, key)
 		if err != nil {
 			return 0, err
 		}
@@ -454,13 +484,13 @@ func (s *Storage) deleteHash(ctx context.Context, db int64, keys [][]byte) (int6
 	var deleteNum int64
 	for _, key := range keys {
 		// Get fields by key
-		fields, err := s.HKeys(ctx, db, key)
+		fields, err := s.HKeys(ctx, "hkeys", db, key)
 		if err != nil {
 			return 0, err
 		}
 
 		// Delete
-		num, err := s.HDel(ctx, db, key, fields)
+		num, err := s.HDel(ctx, "hdel", db, key, fields)
 		if err != nil {
 			return 0, err
 		}
@@ -472,11 +502,14 @@ func (s *Storage) deleteHash(ctx context.Context, db int64, keys [][]byte) (int6
 
 // expireHash expire hash table
 func (s *Storage) expireHash(ctx context.Context, db int64, key []byte, expire_ts table.TimeStamp) (int, error) {
-	tableName := hashTableName
+	tableName, err := s.getTableNameByCmdName("hkeys")
+	if err != nil {
+		return 0, err
+	}
 	var res = 0
 
 	// 1. Get all fields
-	fields, err := s.HKeys(ctx, db, key)
+	fields, err := s.HKeys(ctx, "hkeys", db, key)
 	if err != nil {
 		return 0, err
 	}
@@ -511,11 +544,14 @@ func (s *Storage) expireHash(ctx context.Context, db int64, key []byte, expire_t
 
 // persistHash persist hash table
 func (s *Storage) persistHash(ctx context.Context, db int64, key []byte) (int, error) {
-	tableName := hashTableName
+	tableName, err := s.getTableNameByCmdName("hkeys")
+	if err != nil {
+		return 0, err
+	}
 	var res = 0
 
 	// 1. Get all fields
-	fields, err := s.HKeys(ctx, db, key)
+	fields, err := s.HKeys(ctx, "hkeys", db, key)
 	if err != nil {
 		return 0, err
 	}
@@ -550,11 +586,14 @@ func (s *Storage) persistHash(ctx context.Context, db int64, key []byte) (int, e
 
 // ttlHash get expire time of hash table
 func (s *Storage) ttlHash(ctx context.Context, db int64, key []byte) (time.Duration, error) {
-	tableName := hashTableName
+	tableName, err := s.getTableNameByCmdName("hkeys")
+	if err != nil {
+		return 0, err
+	}
 	batchExecutor := s.cli.NewBatchExecutor(tableName)
 
 	// 1. Get all fields
-	fields, err := s.HKeys(ctx, db, key)
+	fields, err := s.HKeys(ctx, "hkeys", db, key)
 	if err != nil {
 		return 0, err
 	}

--- a/storage/obkv/key.go
+++ b/storage/obkv/key.go
@@ -131,6 +131,7 @@ func (s *Storage) Exists(ctx context.Context, db int64, keys [][]byte) (int64, e
 // Delete delete all keys
 func (s *Storage) Delete(ctx context.Context, db int64, keys [][]byte) (int64, error) {
 	var deleteNum int64
+	// TODO:
 	num, err := s.deleteString(ctx, db, keys)
 	if err != nil {
 		return 0, err
@@ -176,7 +177,7 @@ func (s *Storage) Expire(ctx context.Context, db int64, key []byte, at time.Time
 	} else if val != nil {
 		if strings.Contains(string(val), "string") {
 			// expire string
-			_, err = s.expireString(ctx, db, key, table.TimeStamp(at))
+			_, err = s.expireString(ctx, "get", db, key, table.TimeStamp(at))
 			if err != nil {
 				return 0, err
 			}
@@ -240,7 +241,7 @@ func (s *Storage) Persist(ctx context.Context, db int64, key []byte) (int, error
 	}
 
 	// persist string
-	res, err = s.persistString(ctx, db, key)
+	res, err = s.persistString(ctx, "get", db, key)
 	if err != nil {
 		return 0, err
 	}
@@ -286,4 +287,3 @@ func (s *Storage) Persist(ctx context.Context, db int64, key []byte) (int, error
 
 	return 0, nil
 }
-

--- a/storage/obkv/list.go
+++ b/storage/obkv/list.go
@@ -31,14 +31,14 @@ CREATE TABLE modis_list_table(
   db BIGINT NOT NULL,
   rkey VARBINARY(1024) NOT NULL,
   is_data tinyint(1) default 1,
-  insert_ts TIMESTAMP(6) DEFAULT NULL, 
+  insert_ts TIMESTAMP(6) DEFAULT NULL,
   expire_ts timestamp(6) default null,
   value VARBINARY(1024) DEFAULT NULL,
-  `index` BIGINT NOT NULL,             
+  `index` BIGINT NOT NULL,
   PRIMARY KEY(db, rkey, is_data, `index`)
 )
 KV_ATTRIBUTES ='{"Redis": {"isTTL": true, "model": "list"}}'
-PARTITION BY KEY(db, rkey)            
+PARTITION BY KEY(db, rkey)
 PARTITIONS 3;
 */
 
@@ -61,7 +61,7 @@ func (s *Storage) listExists(ctx context.Context, db int64, keys [][]byte) (int6
 			table.NewColumn(keyColumnName, keys[i]),
 			table.NewColumn(indexColumnName, int64(math.MinInt64)),
 		}
-		list_len, err := s.ObServerCmd(ctx, listTableName, rowKey, []byte(encodedArray))
+		list_len, err := s.ObServerCmd(ctx, "llen", rowKey, []byte(encodedArray))
 		if err != nil {
 			return exist_key_count, err
 		}
@@ -94,7 +94,7 @@ func (s *Storage) deleteList(ctx context.Context, db int64, keys [][]byte) (int6
 			table.NewColumn(keyColumnName, keys[i]),
 			table.NewColumn(indexColumnName, int64(math.MinInt64)),
 		}
-		res, err := s.ObServerCmd(ctx, listTableName, rowKey, []byte(encodedArray))
+		res, err := s.ObServerCmd(ctx, "ldel", rowKey, []byte(encodedArray))
 		if err != nil {
 			continue
 		}

--- a/storage/obkv/set.go
+++ b/storage/obkv/set.go
@@ -46,8 +46,11 @@ const (
 )
 
 // SCard get the size of the key
-func (s *Storage) SCard(ctx context.Context, db int64, key []byte) (int64, error) {
-	tableName := setTableName
+func (s *Storage) SCard(ctx context.Context, cmdName string, db int64, key []byte) (int64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Prepare key range
 	startRowKey := []*table.Column{
@@ -77,8 +80,11 @@ func (s *Storage) SCard(ctx context.Context, db int64, key []byte) (int64, error
 }
 
 // SRem remove the member from the key
-func (s *Storage) SRem(ctx context.Context, db int64, key []byte, members [][]byte) (int64, error) {
-	tableName := setTableName
+func (s *Storage) SRem(ctx context.Context, cmdName string, db int64, key []byte, members [][]byte) (int64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	if len(members) == 0 {
 		return 0, nil
@@ -120,8 +126,11 @@ func (s *Storage) SRem(ctx context.Context, db int64, key []byte, members [][]by
 }
 
 // SIsmember check if is a member of the key
-func (s *Storage) SIsmember(ctx context.Context, db int64, key []byte, member []byte) (int, error) {
-	tableName := setTableName
+func (s *Storage) SIsmember(ctx context.Context, cmdName string, db int64, key []byte, member []byte) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -147,8 +156,11 @@ func (s *Storage) SIsmember(ctx context.Context, db int64, key []byte, member []
 }
 
 // SMembers get all member
-func (s *Storage) SMembers(ctx context.Context, db int64, key []byte) ([][]byte, error) {
-	tableName := setTableName
+func (s *Storage) SMembers(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Prepare key range
 	startRowKey := []*table.Column{
@@ -194,8 +206,11 @@ func (s *Storage) SMembers(ctx context.Context, db int64, key []byte) ([][]byte,
 }
 
 // Smove move member from src key to dest key
-func (s *Storage) Smove(ctx context.Context, db int64, src []byte, dst []byte, member []byte) (int, error) {
-	tableName := setTableName
+func (s *Storage) Smove(ctx context.Context, cmdName string, db int64, src []byte, dst []byte, member []byte) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// 1. Delete from src key
 	// Set rowKey columns
@@ -241,9 +256,12 @@ func (s *Storage) Smove(ctx context.Context, db int64, src []byte, dst []byte, m
 }
 
 // SPop randomly delete count members
-func (s *Storage) SPop(ctx context.Context, db int64, key []byte, count int) ([][]byte, error) {
-	tableName := setTableName
-	members, err := s.SRandMember(ctx, db, key, count)
+func (s *Storage) SPop(ctx context.Context, cmdName string, db int64, key []byte, count int) ([][]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
+	members, err := s.SRandMember(ctx, cmdName, db, key, count)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +287,7 @@ func (s *Storage) SPop(ctx context.Context, db int64, key []byte, count int) ([]
 }
 
 // SRandMember randomly get count members
-func (s *Storage) SRandMember(ctx context.Context, db int64, key []byte, count int) ([][]byte, error) {
+func (s *Storage) SRandMember(ctx context.Context, cmdName string, db int64, key []byte, count int) ([][]byte, error) {
 	members := make([][]byte, 0, count)
 	if count == 0 {
 		return members, nil
@@ -291,7 +309,10 @@ func (s *Storage) SRandMember(ctx context.Context, db int64, key []byte, count i
 	keyRanges := []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
 
 	// Create query
-	tableName := setTableName
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 	selectColumns := []string{memberColumnName}
 	resSet, err := s.cli.Query(
 		ctx,
@@ -305,7 +326,7 @@ func (s *Storage) SRandMember(ctx context.Context, db int64, key []byte, count i
 	}
 	defer resSet.Close()
 
-	cnt, err := s.SCard(ctx, db, key)
+	cnt, err := s.SCard(ctx, cmdName, db, key)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +361,7 @@ func (s *Storage) SRandMember(ctx context.Context, db int64, key []byte, count i
 func (s *Storage) setExists(ctx context.Context, db int64, keys [][]byte) (int64, error) {
 	var existNum int64
 	for _, key := range keys {
-		num, err := s.SCard(ctx, db, key)
+		num, err := s.SCard(ctx, "scard", db, key)
 		if err != nil {
 			return 0, err
 		}
@@ -358,13 +379,13 @@ func (s *Storage) deleteSet(ctx context.Context, db int64, keys [][]byte) (int64
 	var deleteNum int64
 	for _, key := range keys {
 		// Get members by key
-		members, err := s.SMembers(ctx, db, key)
+		members, err := s.SMembers(ctx, "smembers", db, key)
 		if err != nil {
 			return 0, err
 		}
 
 		// Delete
-		num, err := s.SRem(ctx, db, key, members)
+		num, err := s.SRem(ctx, "srem", db, key, members)
 		if err != nil {
 			return 0, err
 		}
@@ -376,11 +397,14 @@ func (s *Storage) deleteSet(ctx context.Context, db int64, keys [][]byte) (int64
 
 // expireSet expire set table
 func (s *Storage) expireSet(ctx context.Context, db int64, key []byte, expire_ts table.TimeStamp) (int, error) {
-	tableName := setTableName
+	tableName, err := s.getTableNameByCmdName("smembers")
+	if err != nil {
+		return 0, err
+	}
 	var res = 0
 
 	// 1. Get all members
-	members, err := s.SMembers(ctx, db, key)
+	members, err := s.SMembers(ctx, "smembers", db, key)
 	if err != nil {
 		return 0, err
 	}
@@ -415,11 +439,14 @@ func (s *Storage) expireSet(ctx context.Context, db int64, key []byte, expire_ts
 
 // persistSet persist set table
 func (s *Storage) persistSet(ctx context.Context, db int64, key []byte) (int, error) {
-	tableName := setTableName
+	tableName, err := s.getTableNameByCmdName("smembers")
+	if err != nil {
+		return 0, err
+	}
 	var res = 0
 
 	// 1. Get all members
-	members, err := s.SMembers(ctx, db, key)
+	members, err := s.SMembers(ctx, "smembers", db, key)
 	if err != nil {
 		return 0, err
 	}
@@ -454,11 +481,14 @@ func (s *Storage) persistSet(ctx context.Context, db int64, key []byte) (int, er
 
 // ttlSet get expire time of set table
 func (s *Storage) ttlSet(ctx context.Context, db int64, key []byte) (time.Duration, error) {
-	tableName := setTableName
+	tableName, err := s.getTableNameByCmdName("smembers")
+	if err != nil {
+		return 0, err
+	}
 	batchExecutor := s.cli.NewBatchExecutor(tableName)
 
 	// 1. Get all members
-	members, err := s.SMembers(ctx, db, key)
+	members, err := s.SMembers(ctx, "smembers", db, key)
 	if err != nil {
 		return 0, err
 	}

--- a/storage/obkv/strings.go
+++ b/storage/obkv/strings.go
@@ -44,9 +44,11 @@ const (
 )
 
 // Get value by key. Return value if exists, nil if not exists
-func (s *Storage) Get(ctx context.Context, db int64, key []byte) ([]byte, error) {
-	tableName := stringTableName
-
+func (s *Storage) Get(ctx context.Context, cmdName string, db int64, key []byte) ([]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 	// Set rowKey columns
 	rowKey := []*table.Column{
 		table.NewColumn(dbColumnName, db),
@@ -69,8 +71,11 @@ func (s *Storage) Get(ctx context.Context, db int64, key []byte) ([]byte, error)
 }
 
 // MGet obtain key-value pairs in batches. If keys do not exist, null is returned.
-func (s *Storage) MGet(ctx context.Context, db int64, keys [][]byte) ([][]byte, error) {
-	tableName := stringTableName
+func (s *Storage) MGet(ctx context.Context, cmdName string, db int64, keys [][]byte) ([][]byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return nil, err
+	}
 	batchExecutor := s.cli.NewBatchExecutor(tableName)
 
 	// Add get operations
@@ -108,8 +113,11 @@ func (s *Storage) MGet(ctx context.Context, db int64, keys [][]byte) ([][]byte, 
 
 // MSet set key pairs in batches. If the key already exists, the old value is overwritten.
 // Returns the number of keys successfully set
-func (s *Storage) MSet(ctx context.Context, db int64, kv map[string][]byte) (int, error) {
-	tableName := stringTableName
+func (s *Storage) MSet(ctx context.Context, cmdName string, db int64, kv map[string][]byte) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 	batchExecutor := s.cli.NewBatchExecutor(tableName)
 
 	// Add insert operations
@@ -139,8 +147,11 @@ func (s *Storage) MSet(ctx context.Context, db int64, kv map[string][]byte) (int
 }
 
 // PSetEx set the value and expiration time (in milliseconds), update key if the key already exists.
-func (s *Storage) PSetEx(ctx context.Context, db int64, key []byte, expireTime uint64, value []byte) error {
-	tableName := stringTableName
+func (s *Storage) PSetEx(ctx context.Context, cmdName string, db int64, key []byte, expireTime uint64, value []byte) error {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -155,7 +166,7 @@ func (s *Storage) PSetEx(ctx context.Context, db int64, key []byte, expireTime u
 	}
 
 	// Execute
-	_, err := s.cli.InsertOrUpdate(ctx, tableName, rowKey, mutates)
+	_, err = s.cli.InsertOrUpdate(ctx, tableName, rowKey, mutates)
 	if err != nil {
 		return err
 	}
@@ -164,9 +175,11 @@ func (s *Storage) PSetEx(ctx context.Context, db int64, key []byte, expireTime u
 }
 
 // Set the value of the specified key, insert if it does not exist and update if it does.
-func (s *Storage) Set(ctx context.Context, db int64, key []byte, value []byte) error {
-	tableName := stringTableName
-
+func (s *Storage) Set(ctx context.Context, cmdName string, db int64, key []byte, value []byte) error {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return err
+	}
 	// Set rowKey columns
 	rowKey := []*table.Column{
 		table.NewColumn(dbColumnName, db),
@@ -180,7 +193,7 @@ func (s *Storage) Set(ctx context.Context, db int64, key []byte, value []byte) e
 	}
 
 	// Execute
-	_, err := s.cli.InsertOrUpdate(ctx, tableName, rowKey, mutates)
+	_, err = s.cli.InsertOrUpdate(ctx, tableName, rowKey, mutates)
 	if err != nil {
 		return err
 	}
@@ -188,8 +201,11 @@ func (s *Storage) Set(ctx context.Context, db int64, key []byte, value []byte) e
 }
 
 // SetEx set the value and expiration time (in second), update key if the key already exists.
-func (s *Storage) SetEx(ctx context.Context, db int64, key []byte, expireTime uint64, value []byte) error {
-	tableName := stringTableName
+func (s *Storage) SetEx(ctx context.Context, cmdName string, db int64, key []byte, expireTime uint64, value []byte) error {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -204,7 +220,7 @@ func (s *Storage) SetEx(ctx context.Context, db int64, key []byte, expireTime ui
 	}
 
 	// Execute
-	_, err := s.cli.InsertOrUpdate(ctx, tableName, rowKey, mutates)
+	_, err = s.cli.InsertOrUpdate(ctx, tableName, rowKey, mutates)
 	if err != nil {
 		return err
 	}
@@ -213,8 +229,11 @@ func (s *Storage) SetEx(ctx context.Context, db int64, key []byte, expireTime ui
 }
 
 // SetNx set a key-value pair, returning 0 if the key already exists and setting a value if the key does not exist.
-func (s *Storage) SetNx(ctx context.Context, db int64, key []byte, value []byte) (int, error) {
-	tableName := stringTableName
+func (s *Storage) SetNx(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -228,7 +247,7 @@ func (s *Storage) SetNx(ctx context.Context, db int64, key []byte, value []byte)
 	}
 
 	// Execute, return 0 if key exist, return 1 if key not exist.
-	_, err := s.cli.Insert(ctx, tableName, rowKey, mutates)
+	_, err = s.cli.Insert(ctx, tableName, rowKey, mutates)
 	if err != nil {
 		errString := err.Error()
 		errMsg := "errCode:-5024"
@@ -243,8 +262,11 @@ func (s *Storage) SetNx(ctx context.Context, db int64, key []byte, value []byte)
 }
 
 // Append appends a string to the value of the key. Returns the length of the final value.
-func (s *Storage) Append(ctx context.Context, db int64, key []byte, value []byte) (int, error) {
-	tableName := stringTableName
+func (s *Storage) Append(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -269,8 +291,11 @@ func (s *Storage) Append(ctx context.Context, db int64, key []byte, value []byte
 // IncrBy Add value from the value of the key.
 // If the key does not exist, value is written and value is returned
 // Returns the value add value when key is present;
-func (s *Storage) IncrBy(ctx context.Context, db int64, key []byte, value []byte) (int64, error) {
-	tableName := stringTableName
+func (s *Storage) IncrBy(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (int64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -302,8 +327,11 @@ func (s *Storage) IncrBy(ctx context.Context, db int64, key []byte, value []byte
 // IncrByFloat Add value from the value of the key.
 // If the key does not exist, value is written and value is returned
 // Returns the value add value when key is present;
-func (s *Storage) IncrByFloat(ctx context.Context, db int64, key []byte, value []byte) (float64, error) {
-	tableName := stringTableName
+func (s *Storage) IncrByFloat(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (float64, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -333,8 +361,11 @@ func (s *Storage) IncrByFloat(ctx context.Context, db int64, key []byte, value [
 }
 
 // GetBit get the bit value of the specified offset position in the value of the specified key.
-func (s *Storage) GetBit(ctx context.Context, db int64, key []byte, offset int) (byte, error) {
-	tableName := stringTableName
+func (s *Storage) GetBit(ctx context.Context, cmdName string, db int64, key []byte, offset int) (byte, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -367,7 +398,7 @@ func (s *Storage) GetBit(ctx context.Context, db int64, key []byte, offset int) 
 // stringExists check the number of keys that exist in string table
 func (s *Storage) stringExists(ctx context.Context, db int64, keys [][]byte) (int64, error) {
 	var num int64 = 0
-	values, err := s.MGet(ctx, db, keys)
+	values, err := s.MGet(ctx, "mget", db, keys)
 	if err != nil {
 		return 0, err
 	}
@@ -382,7 +413,10 @@ func (s *Storage) stringExists(ctx context.Context, db int64, keys [][]byte) (in
 
 // deleteString delete string table
 func (s *Storage) deleteString(ctx context.Context, db int64, keys [][]byte) (int64, error) {
-	tableName := stringTableName
+	tableName, err := s.getTableNameByCmdName("get")
+	if err != nil {
+		return 0, err
+	}
 	batchExecutor := s.cli.NewBatchExecutor(tableName)
 
 	// Add delete operations
@@ -414,8 +448,11 @@ func (s *Storage) deleteString(ctx context.Context, db int64, keys [][]byte) (in
 }
 
 // expireString expire string table
-func (s *Storage) expireString(ctx context.Context, db int64, key []byte, expire_ts table.TimeStamp) (int, error) {
-	tableName := stringTableName
+func (s *Storage) expireString(ctx context.Context, cmdName string, db int64, key []byte, expire_ts table.TimeStamp) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -438,8 +475,11 @@ func (s *Storage) expireString(ctx context.Context, db int64, key []byte, expire
 }
 
 // persistString persist string table
-func (s *Storage) persistString(ctx context.Context, db int64, key []byte) (int, error) {
-	tableName := stringTableName
+func (s *Storage) persistString(ctx context.Context, cmdName string, db int64, key []byte) (int, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{
@@ -462,8 +502,11 @@ func (s *Storage) persistString(ctx context.Context, db int64, key []byte) (int,
 }
 
 // ttlString get expire time of string table
-func (s *Storage) ttlString(ctx context.Context, db int64, key []byte) (time.Duration, error) {
-	tableName := stringTableName
+func (s *Storage) ttlString(ctx context.Context, cmdName string, db int64, key []byte) (time.Duration, error) {
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return 0, err
+	}
 
 	// Set rowKey columns
 	rowKey := []*table.Column{

--- a/storage/obkv/utils.go
+++ b/storage/obkv/utils.go
@@ -52,11 +52,14 @@ func getRandomArray(min int, max int, count int) []int {
 }
 
 // ObServerCmd is a general interface for commands that can be executed on the observer side
-func (s *Storage) ObServerCmd(ctx context.Context, tableName string, rowKey []*table.Column, plainText []byte) (string, error) {
+func (s *Storage) ObServerCmd(ctx context.Context, cmdName string, rowKey []*table.Column, plainText []byte) (string, error) {
 	mutateColumns := []*table.Column{
 		table.NewColumn("REDIS_CODE_STR", plainText),
 	}
-
+	tableName, err := s.getTableNameByCmdName(cmdName)
+	if err != nil {
+		return "", err
+	}
 	// Create query
 	result, err := s.cli.Redis(
 		ctx,

--- a/storage/obkv/zset.go
+++ b/storage/obkv/zset.go
@@ -58,7 +58,7 @@ func (s *Storage) zsetExists(ctx context.Context, db int64, keys [][]byte) (int6
 			table.NewColumn(keyColumnName, key),
 		}
 
-		outContent, err := s.ObServerCmd(ctx, zsetTableName, rowKey, []byte(encodedArray))
+		outContent, err := s.ObServerCmd(ctx, "zremrange", rowKey, []byte(encodedArray))
 		if err != nil {
 			return 0, err
 		}
@@ -91,7 +91,7 @@ func (s *Storage) deleteZSet(ctx context.Context, db int64, keys [][]byte) (int6
 			table.NewColumn(keyColumnName, key),
 		}
 
-		outContent, err := s.ObServerCmd(ctx, zsetTableName, rowKey, []byte(encodedArray))
+		outContent, err := s.ObServerCmd(ctx, "zremrange", rowKey, []byte(encodedArray))
 		if err != nil {
 			return 0, err
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -37,44 +37,44 @@ type Storage interface {
 	Persist(ctx context.Context, db int64, key []byte) (int, error)
 
 	// string commands
-	Get(ctx context.Context, db int64, key []byte) ([]byte, error)
-	Set(ctx context.Context, db int64, key []byte, value []byte) error
-	PSetEx(ctx context.Context, db int64, key []byte, expireTime uint64, value []byte) error
-	SetEx(ctx context.Context, db int64, key []byte, expireTime uint64, value []byte) error
-	MGet(ctx context.Context, db int64, keys [][]byte) ([][]byte, error)
-	MSet(ctx context.Context, db int64, kv map[string][]byte) (int, error)
-	SetNx(ctx context.Context, db int64, key []byte, value []byte) (int, error)
-	Append(ctx context.Context, db int64, key []byte, value []byte) (int, error)
-	IncrBy(ctx context.Context, db int64, key []byte, value []byte) (int64, error)
-	IncrByFloat(ctx context.Context, db int64, key []byte, value []byte) (float64, error)
-	GetBit(ctx context.Context, db int64, key []byte, offset int) (byte, error)
+	Get(ctx context.Context, cmdName string, db int64, key []byte) ([]byte, error)
+	Set(ctx context.Context, cmdName string, db int64, key []byte, value []byte) error
+	PSetEx(ctx context.Context, cmdName string, db int64, key []byte, expireTime uint64, value []byte) error
+	SetEx(ctx context.Context, cmdName string, db int64, key []byte, expireTime uint64, value []byte) error
+	MGet(ctx context.Context, cmdName string, db int64, keys [][]byte) ([][]byte, error)
+	MSet(ctx context.Context, cmdName string, db int64, kv map[string][]byte) (int, error)
+	SetNx(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (int, error)
+	Append(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (int, error)
+	IncrBy(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (int64, error)
+	IncrByFloat(ctx context.Context, cmdName string, db int64, key []byte, value []byte) (float64, error)
+	GetBit(ctx context.Context, cmdName string, db int64, key []byte, offset int) (byte, error)
 
 	// hash commands
-	HSetNx(ctx context.Context, db int64, key []byte, field []byte, value []byte) (int, error)
-	HMGet(ctx context.Context, db int64, key []byte, fields [][]byte) ([][]byte, error)
-	HGet(ctx context.Context, db int64, key []byte, field []byte) ([]byte, error)
-	HDel(ctx context.Context, db int64, key []byte, fields [][]byte) (int64, error)
-	HGetAll(ctx context.Context, db int64, key []byte) ([][]byte, error)
-	HKeys(ctx context.Context, db int64, key []byte) ([][]byte, error)
-	HVals(ctx context.Context, db int64, key []byte) ([][]byte, error)
-	HLen(ctx context.Context, db int64, key []byte) (int64, error)
-	HIncrBy(ctx context.Context, db int64, key []byte, field []byte, value []byte) (int64, error)
-	HIncrByFloat(ctx context.Context, db int64, key []byte, field []byte, value []byte) (float64, error)
+	HSetNx(ctx context.Context, cmdName string, db int64, key []byte, field []byte, value []byte) (int, error)
+	HMGet(ctx context.Context, cmdName string, db int64, key []byte, fields [][]byte) ([][]byte, error)
+	HGet(ctx context.Context, cmdName string, db int64, key []byte, field []byte) ([]byte, error)
+	HDel(ctx context.Context, cmdName string, db int64, key []byte, fields [][]byte) (int64, error)
+	HGetAll(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error)
+	HKeys(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error)
+	HVals(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error)
+	HLen(ctx context.Context, cmdName string, db int64, key []byte) (int64, error)
+	HIncrBy(ctx context.Context, cmdName string, db int64, key []byte, field []byte, value []byte) (int64, error)
+	HIncrByFloat(ctx context.Context, cmdName string, db int64, key []byte, field []byte, value []byte) (float64, error)
 
 	// set commands
-	SCard(ctx context.Context, db int64, key []byte) (int64, error)
-	SIsmember(ctx context.Context, db int64, key []byte, member []byte) (int, error)
-	SMembers(ctx context.Context, db int64, key []byte) ([][]byte, error)
-	Smove(ctx context.Context, db int64, src []byte, dst []byte, member []byte) (int, error)
-	SPop(ctx context.Context, db int64, key []byte, count int) ([][]byte, error)
-	SRandMember(ctx context.Context, db int64, key []byte, count int) ([][]byte, error)
-	SRem(ctx context.Context, db int64, key []byte, members [][]byte) (int64, error)
+	SCard(ctx context.Context, cmdName string, db int64, key []byte) (int64, error)
+	SIsmember(ctx context.Context, cmdName string, db int64, key []byte, member []byte) (int, error)
+	SMembers(ctx context.Context, cmdName string, db int64, key []byte) ([][]byte, error)
+	Smove(ctx context.Context, cmdName string, db int64, src []byte, dst []byte, member []byte) (int, error)
+	SPop(ctx context.Context, cmdName string, db int64, key []byte, count int) ([][]byte, error)
+	SRandMember(ctx context.Context, cmdName string, db int64, key []byte, count int) ([][]byte, error)
+	SRem(ctx context.Context, cmdName string, db int64, key []byte, members [][]byte) (int64, error)
 
 	// server commands
 	GetTableInfo(ctx context.Context, db int64, tableName string) (*obkv.TableInfo, error)
 
 	// general interface for commands that can be executed on the observer side
-	ObServerCmd(ctx context.Context, tableName string, rowKey []*table.Column, plainText []byte) (string, error)
+	ObServerCmd(ctx context.Context, cmdName string, rowKey []*table.Column, plainText []byte) (string, error)
 
 	Close() error
 }

--- a/test/util.go
+++ b/test/util.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/fsnotify/fsnotify"
 	"os"
 	"strconv"
+
+	"github.com/fsnotify/fsnotify"
 
 	"github.com/oceanbase/modis/config"
 	"github.com/oceanbase/modis/log"
@@ -47,10 +48,10 @@ const (
 
 // Config for Tests
 const (
-	SqlUser     = "root@mysql"
+	SqlUser     = "root@mysql_tenant"
 	SqlPassWord = ""
-	SqlIp       = "127.0.0.1"
-	SqlPort     = "20903"
+	SqlIp       = "11.162.218.236"
+	SqlPort     = "55605"
 	SqlDatabase = "test"
 )
 

--- a/test/util.go
+++ b/test/util.go
@@ -48,10 +48,10 @@ const (
 
 // Config for Tests
 const (
-	SqlUser     = "root@mysql_tenant"
+	SqlUser     = "root@mysql"
 	SqlPassWord = ""
-	SqlIp       = "11.162.218.236"
-	SqlPort     = "55605"
+	SqlIp       = "20903"
+	SqlPort     = "20903"
 	SqlDatabase = "test"
 )
 


### PR DESCRIPTION
## Summary
+ Implemented logic to fetch the cmdName to table mapping from the system table records
+ Updated related functions and invocations to accommodate the dynamic mapping retrieval.


