### PR TITLE
Modis performance optimizing

### DIFF
--- a/connection/conncontext/codec_context.go
+++ b/connection/conncontext/codec_context.go
@@ -105,14 +105,6 @@ func NewCodecCtx(conn net.Conn, id int64, db *storage.DB, queLimit int) *CodecCo
 	rc := &ReadCounter{reader: conn}
 	cc.TotalBytes = &rc.TotalBytes
 	cc.Reader = bufio.NewReader(rc)
-	if tcpConn, ok := conn.(*net.TCPConn); ok {
-		file, err := tcpConn.File()
-		if err == nil {
-			// closing file does not affect conn
-			defer file.Close()
-			cc.Fd = int(file.Fd())
-		}
-	}
 	return cc
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
* Replace with custom util.ReadBytesNoClone in RedisCodec.readCommand
* bug fix: the TCP to redis-cli is set to non-blocking by tcp.File(removed)

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

A custom function `util.ReadBytesNoClone` replaces the original `bufio.ReadBytes` to avoid allocating and copying.

The TCP connection to redis-cli was accidentally set to non-blocking mode(by tcp.File function), which caused the bufio library to repeatedly call the system call "read". (just remove the code fragment.)
